### PR TITLE
Handle providers listed with subdomains

### DIFF
--- a/lib/furlex/oembed.ex
+++ b/lib/furlex/oembed.ex
@@ -86,7 +86,7 @@ defmodule Furlex.Oembed do
   end
 
   defp host_matches?(host, %{"provider_url" => provider_url}) do
-    Regex.match?(~r/https?:\/\/#{host}/, provider_url)
+    Regex.match?(~r/https?:\/\/([a-zA-Z0-9]+\.)?#{host}/, provider_url)
   end
 
   ## GenServer callbacks

--- a/test/fixtures/providers.json
+++ b/test/fixtures/providers.json
@@ -1,5 +1,18 @@
 [
   {
+    "provider_name": "Twitter",
+    "provider_url": "http:\/\/www.twitter.com/",
+    "endpoints": [
+      {
+        "schemes": [
+          "https:\/\/twitter.com\/*\/status\/*",
+          "https:\/\/*.twitter.com\/*\/status\/*"
+        ],
+        "url": "https:\/\/publish.twitter.com\/oembed"
+      }
+    ]
+  },
+  {
     "provider_name": "VideoJug",
     "provider_url": "http:\/\/www.videojug.com",
     "endpoints": [

--- a/test/furlex/oembed_test.exs
+++ b/test/furlex/oembed_test.exs
@@ -34,6 +34,20 @@ defmodule Furlex.OembedTest do
     assert endpoint == "https://vimeo.com/api/oembed.json"
   end
 
+  test "returns endpoint from url with subdomain", %{bypass: bypass} do
+    Bypass.expect(bypass, &handle/1)
+
+    assert {:error, :no_oembed_provider} ==
+             Oembed.endpoint_from_url("foobar")
+
+    url = "https://twitter.com/arshia__/status/1204481088422178817?s=20"
+    params = %{"format" => "json"}
+
+    {:ok, endpoint} = Oembed.endpoint_from_url(url, params, skip_cache?: true)
+
+    assert endpoint == "https://publish.twitter.com/oembed"
+  end
+
   def handle(%{request_path: "/providers.json"} = conn) do
     assert conn.method == "GET"
 


### PR DESCRIPTION
host_matches? previously would fail to match providers with URLs such
as http://www.twitter.com/. Generalized the regex to handle subdomains.