### PR TITLE
increase Task timeout and add test async

### DIFF
--- a/lib/furlex.ex
+++ b/lib/furlex.ex
@@ -72,7 +72,7 @@ defmodule Furlex do
   defp fetch(url, opts) do
     fetch = Task.async(Fetcher, :fetch, [url, opts])
     fetch_oembed = Task.async(Fetcher, :fetch_oembed, [url, opts])
-    yield = Task.yield_many([fetch, fetch_oembed])
+    yield = Task.yield_many([fetch, fetch_oembed], 10_000)
 
     with [fetch, fetch_oembed] <- yield,
          {_fetch, {:ok, {:ok, body, status_code}}} <- fetch,
@@ -87,7 +87,7 @@ defmodule Furlex do
     parse = &Task.async(&1, :parse, [body])
     tasks = Enum.map([Facebook, Twitter, JsonLD, HTML], parse)
 
-    with [facebook, twitter, json_ld, other] <- Task.yield_many(tasks),
+    with [facebook, twitter, json_ld, other] <- Task.yield_many(tasks, 18_000),
          {_facebook, {:ok, {:ok, facebook}}} <- facebook,
          {_twitter, {:ok, {:ok, twitter}}} <- twitter,
          {_json_ld, {:ok, {:ok, json_ld}}} <- json_ld,

--- a/test/furlex/parser/facebook_test.exs
+++ b/test/furlex/parser/facebook_test.exs
@@ -1,9 +1,13 @@
 defmodule Furlex.Parser.FacebookTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Furlex.Parser.Facebook
 
   doctest Facebook
+
+  setup do
+    Application.put_env(:furlex, :group_keys?, true)
+  end
 
   test "parses Facebook Open Graph" do
     html =

--- a/test/furlex/parser/twitter_test.exs
+++ b/test/furlex/parser/twitter_test.exs
@@ -1,9 +1,13 @@
 defmodule Furlex.Parser.TwitterTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Furlex.Parser.Twitter
 
   doctest Twitter
+
+  setup do
+    Application.put_env(:furlex, :group_keys?, true)
+  end
 
   test "parses Twitter Cards" do
     html =

--- a/test/furlex_test.exs
+++ b/test/furlex_test.exs
@@ -1,5 +1,5 @@
 defmodule FurlexTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   setup do
     bypass = Bypass.open()


### PR DESCRIPTION
With [Task.yield_many/2](https://hexdocs.pm/elixir/Task.html#yield_many/2), a timeout is expected.
This PR simply increase the `timeout` to resolve the case in https://github.com/claytongentry/furlex/issues/27.
For the case [tests fail intermittently](https://github.com/claytongentry/furlex/issues/28), It's still `Task` timeout issue when tests are running in the same process so we use `async: true` to run the test case concurrently.